### PR TITLE
Memoryless livedata returned the current value as null. When we want …

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Development]
+- Fix: value get null issue fixed. 
 
 ## Bursa(0.0.4)
 - LiveDataAction implementation.

--- a/src/main/java/me/ibrahimyilmaz/arch_data/MemoryLessLiveData.kt
+++ b/src/main/java/me/ibrahimyilmaz/arch_data/MemoryLessLiveData.kt
@@ -46,5 +46,6 @@ internal class MemoryLessLiveData<T> : MutableLiveData<T>() {
         singleDataEvent.value = SingleLiveDataEvent(observers, value)
     }
 
+    override fun getValue(): T? = singleDataEvent.value?.peekContent()
 }
 

--- a/src/main/java/me/ibrahimyilmaz/arch_data/SingleLiveDataEvent.kt
+++ b/src/main/java/me/ibrahimyilmaz/arch_data/SingleLiveDataEvent.kt
@@ -7,11 +7,15 @@ internal class SingleLiveDataEvent<T>(observers: MutableCollection<Observer<in T
 
     private val receiverObservers = ArrayList(observers)
 
-    fun getContentIfNotHandled(observer: Observer<in T>): T? =
-            receiverObservers.firstOrNull { it == observer }?.let {
-                receiverObservers.remove(it)
-                content
-            }
+    fun getContentIfNotHandled(observer: Observer<in T>): T? {
+        val observer = receiverObservers.firstOrNull { it == observer } ?: return null
+
+        receiverObservers.remove(observer)
+        return content
+    }
+
+
+    fun peekContent() = content
 }
 
 

--- a/src/test/java/me/ibrahimyilmaz/arch_data/MemoryLessLiveDataTest.kt
+++ b/src/test/java/me/ibrahimyilmaz/arch_data/MemoryLessLiveDataTest.kt
@@ -42,4 +42,16 @@ class MemoryLessLiveDataTest {
         assertEquals(false, containsAnyObserverForLifeCycleOwner)
         assertEquals(true, containsAnyObserverForLifeCycleOwner2)
     }
+
+    @Test
+    fun should_set_the_value_of_the_memoryless_livedata() {
+        // GIVEN
+        val value = 3
+
+        // WHEN
+        liveData.setValue(value)
+
+        // THEN
+        assertEquals(liveData.value, value)
+    }
 }

--- a/src/test/java/me/ibrahimyilmaz/arch_data/PublishLiveDataTest.kt
+++ b/src/test/java/me/ibrahimyilmaz/arch_data/PublishLiveDataTest.kt
@@ -1,9 +1,9 @@
 package me.ibrahimyilmaz.arch_data
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -144,4 +144,16 @@ class PublishLiveDataTest {
         inOrderVerifier.verifyNoMoreInteractions()
     }
 
+
+    @Test
+    fun should_set_the_value_of_the_publish_livedata() {
+        //GIVEN
+        val value = 3
+
+        //WHEN
+        liveData.setValue(value)
+
+        //THEN
+        assertEquals(liveData.value, value)
+    }
 }

--- a/src/test/java/me/ibrahimyilmaz/arch_data/ReplayLiveDataTest.kt
+++ b/src/test/java/me/ibrahimyilmaz/arch_data/ReplayLiveDataTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
+import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -83,6 +84,7 @@ class ReplayLiveDataTest {
 
         liveData.postValue(6)
 
+        //THEN
         val inOrderVerifier = inOrder(observer)
         inOrderVerifier.verify(observer).onChanged(1)
         inOrderVerifier.verify(observer).onChanged(2)
@@ -94,6 +96,18 @@ class ReplayLiveDataTest {
         inOrderVerifier.verify(observer).onChanged(5)
         inOrderVerifier.verify(observer).onChanged(6)
         inOrderVerifier.verifyNoMoreInteractions()
+    }
+
+    @Test
+    fun should_set_the_value_of_the_replay_livedata() {
+        //GIVEN
+        val value = 3
+
+        //WHEN
+        liveData.setValue(value)
+
+        //THEN
+        assertEquals(liveData.value, value)
     }
 
 }


### PR DESCRIPTION
…to reach it, we always got null. That issue is fixed.